### PR TITLE
Support for Platform Features

### DIFF
--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -282,6 +282,34 @@ func TestParseSelector(t *testing.T) {
 			},
 			formatted: joinNotEmpty("darwin", defaultArch),
 		},
+		{
+			input: "macOS:avx512",
+			expected: specs.Platform{
+				OS:           "darwin",
+				Architecture: defaultArch,
+				Features:     []string{"avx512"},
+			},
+			formatted: joinNotEmpty("darwin", defaultArch) + ":avx512",
+		},
+		{
+			input: "linux/s390x:avx512:cuda",
+			expected: specs.Platform{
+				OS:           "linux",
+				Architecture: "s390x",
+				Features:     []string{"avx512", "cuda"},
+			},
+			formatted: "linux/s390x:avx512:cuda",
+		},
+		{
+			input: "linux/s390x/v7:avx512:cuda1:cuda2",
+			expected: specs.Platform{
+				OS:           "linux",
+				Architecture: "s390x",
+				Variant:      "v7",
+				Features:     []string{"avx512", "cuda1", "cuda2"},
+			},
+			formatted: "linux/s390x/v7:avx512:cuda1:cuda2",
+		},
 	} {
 		t.Run(testcase.input, func(t *testing.T) {
 			if testcase.skip {
@@ -347,6 +375,12 @@ func TestParseSelectorInvalid(t *testing.T) {
 		},
 		{
 			input: "linux/arm/foo/bar", // too many components
+		},
+		{
+			input: "linux/arm/foo:bar:", // empty feature
+		},
+		{
+			input: "linux/arm/foo::bar", // empty feature
 		},
 	} {
 		t.Run(testcase.input, func(t *testing.T) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -28,7 +28,7 @@ google.golang.org/grpc v1.12.0
 github.com/pkg/errors v0.8.0
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 golang.org/x/sys 1b2967e3c290b7c545b3db0deeda16e9be4f98a2 https://github.com/golang/sys
-github.com/opencontainers/image-spec v1.0.1
+github.com/opencontainers/image-spec 49181e21698eba4761c560fc4476dc49bee8b9e2 https://github.com/qnib/image-spec.git
 golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
@@ -61,4 +61,8 @@ type Platform struct {
 	// Variant is an optional field specifying a variant of the CPU, for
 	// example `v7` to specify ARMv7 when architecture is `arm`.
 	Variant string `json:"variant,omitempty"`
+
+	// Features is an optional field specifying an array of strings,
+	// each listing a required general feature (CPU feature like `avx512` or CUDA driver version).
+	Features []string `json:"features,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -20,12 +20,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 1
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 0
+	VersionMinor = 1
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Change image-spec dependency (now depending on fork which defines platform features) and adopt platform spec parsing, formatting and platform matching accordingly (including unit tests)